### PR TITLE
hash_to_group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,14 @@ name = "api"
 
 [dependencies]
 byteorder = "1.3.4"
+digest = { version = "0.9", optional = true }
+generic-array = { version = "0.14", optional = true }
 rand = "0.7.3"
 serde = "1.0.118"
 serde_derive = "1.0.118"
+
+[features]
+hash-to-curve = ["digest", "generic-array"]
 
 [dev-dependencies.bincode]
 version = "1.0.0"

--- a/src/arith.rs
+++ b/src/arith.rs
@@ -143,6 +143,23 @@ impl U256 {
         U512::random(rng).divrem(modulo).1
     }
 
+    /// Interpret bytes (mod `modulo`)
+    pub fn from_bytes(bytes: &[u8; 32]) -> U256 {
+        let mut n = [0; 4];
+        for l in 0..4 {
+            n[l] = BigEndian::read_u64(&bytes[(l * 8)..]);
+        }
+        U256(n)
+    }
+
+    pub fn to_bytes(&self) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        for l in 0..4 {
+            BigEndian::write_u64(&mut out[(l * 8)..], self.0[l]);
+        }
+        out
+    }
+
     pub fn is_zero(&self) -> bool {
         self.0[0] == 0 && self.0[1] == 0 && self.0[2] == 0 && self.0[3] == 0
     }

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -71,14 +71,32 @@ macro_rules! field_impl {
                 }
             }
 
+            pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+                let mut buf = [0u8; 32];
+                buf.clone_from_slice(bytes);
+                let u = U256::from_bytes(&buf);
+                $name::new(u)
+            }
+
             pub fn interpret(buf: &[u8; 64]) -> Self {
                 $name::new(U512::interpret(buf).divrem(&U256($modulus)).1).unwrap()
+            }
+
+            pub fn into_bytes(self) -> Vec<u8> {
+                U256::from(self).to_bytes().into()
             }
 
             /// Returns the modulus
             #[inline]
             pub fn modulus() -> U256 {
                 U256($modulus)
+            }
+
+            pub fn sqrt(&self) -> Self {
+                // let two = U256::from(2);
+                // let p = Self::modulus().add(U256::one(), U256) / two;
+
+                self.clone()
             }
         }
 

--- a/src/fields/fq12.rs
+++ b/src/fields/fq12.rs
@@ -76,6 +76,20 @@ impl Fq12 {
         Fq12 { c0: c0, c1: c1 }
     }
 
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        assert_eq!(bytes.len(), 384);
+        Some(Fq12 {
+            c0: Fq6::from_bytes(&bytes[..192])?,
+            c1: Fq6::from_bytes(&bytes[192..])?,
+        })
+    }
+
+    pub fn into_bytes(&self) -> Vec<u8> {
+        let mut bytes = self.c0.into_bytes();
+        bytes.extend(self.c1.into_bytes());
+        bytes
+    }
+
     fn final_exponentiation_first_chunk(&self) -> Option<Fq12> {
         match self.inverse() {
             Some(b) => {

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -72,6 +72,20 @@ impl Fq2 {
         Fq2 { c0: c0, c1: c1 }
     }
 
+    pub fn into_bytes(self) -> Vec<u8> {
+        let mut bytes = self.c0.into_bytes();
+        bytes.extend(self.c1.into_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        assert_eq!(bytes.len(), 64);
+        Some(Fq2 {
+            c0: Fq::from_bytes(&bytes[..32])?,
+            c1: Fq::from_bytes(&bytes[32..])?,
+        })
+    }
+
     pub fn scale(&self, by: Fq) -> Self {
         Fq2 {
             c0: self.c0 * by,

--- a/src/fields/fq6.rs
+++ b/src/fields/fq6.rs
@@ -139,6 +139,22 @@ impl Fq6 {
         }
     }
 
+    pub fn into_bytes(self) -> Vec<u8> {
+        let mut bytes = self.c0.into_bytes();
+        bytes.extend(self.c1.into_bytes());
+        bytes.extend(self.c2.into_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        assert_eq!(bytes.len(), 192);
+        Some(Fq6 {
+            c0: Fq2::from_bytes(&bytes[..64])?,
+            c1: Fq2::from_bytes(&bytes[64..128])?,
+            c2: Fq2::from_bytes(&bytes[128..])?,
+        })
+    }
+
     pub fn mul_by_nonresidue(&self) -> Self {
         Fq6 {
             c0: self.c2.mul_by_nonresidue(),

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -81,6 +81,67 @@ fn test_fq12() {
 }
 
 #[test]
+fn fq_test_into_bytes() {
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..1000 {
+        let fq = Fq::random(&mut rng);
+        let vec = fq.into_bytes();
+        assert_eq!(vec.len(), 32);
+        assert_eq!(Fq::from_bytes(&vec).unwrap(), fq);
+    }
+}
+
+#[test]
+fn fq_test_zero_into_bytes() {
+    let fq = Fq::zero();
+    let vec = fq.into_bytes();
+    assert_eq!(vec.len(), 32);
+    assert_eq!(Fq::from_bytes(&vec).unwrap(), fq);
+}
+
+#[test]
+fn fr_test_one_into_bytes() {
+    let fr = Fr::one();
+    let vec = fr.into_bytes();
+    assert_eq!(vec.len(), 32);
+    assert_eq!(Fr::from_bytes(&vec).unwrap(), fr);
+}
+
+#[test]
+fn fq_test_one_into_bytes() {
+    let fq = Fq::one();
+    println!("{:?}", fq);
+    let vec = fq.into_bytes();
+    assert_eq!(vec.len(), 32);
+    assert_eq!(Fq::from_bytes(&vec).unwrap(), fq);
+}
+
+#[test]
+fn fq12_test_into_bytes() {
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..1000 {
+        let fq12 = Fq12::random(&mut rng);
+        let vec = fq12.into_bytes();
+        assert_eq!(vec.len(), 384);
+        assert_eq!(Fq12::from_bytes(&vec).unwrap(), fq12);
+    }
+}
+
+#[test]
+fn fr_test_into_bytes() {
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..1000 {
+        let fr = Fr::random(&mut rng);
+        let vec = fr.into_bytes();
+        assert_eq!(vec.len(), 32);
+        assert_eq!(Fr::from_bytes(&vec).unwrap(), fr);
+    }
+}
+
+#[test]
 fn fq12_test_vector() {
     let start = Fq12::new(
         Fq6::new(

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -59,6 +59,40 @@ pub struct AffineG<P: GroupParams> {
     y: P::Base,
 }
 
+impl AffineG<G1Params> {
+    pub fn into_bytes(self) -> Vec<u8> {
+        let mut result = Vec::with_capacity(64);
+        result.extend(self.x.into_bytes());
+        result.extend(self.y.into_bytes());
+        result
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        // XXX check whether on curve.
+        Some(AffineG {
+            x: Fq::from_bytes(&bytes[..32])?,
+            y: Fq::from_bytes(&bytes[32..])?,
+        })
+    }
+}
+
+impl AffineG<G2Params> {
+    pub fn into_bytes(self) -> Vec<u8> {
+        let mut result = Vec::with_capacity(64);
+        result.extend(self.x.into_bytes());
+        result.extend(self.y.into_bytes());
+        result
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        // XXX check whether on curve.
+        Some(AffineG {
+            x: Fq2::from_bytes(&bytes[..64])?,
+            y: Fq2::from_bytes(&bytes[64..])?,
+        })
+    }
+}
+
 impl<P: GroupParams> PartialEq for AffineG<P> {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -4,6 +4,11 @@ use arith::U256;
 use std::fmt;
 use rand::Rng;
 
+#[cfg(feature = "digest")]
+use digest::FixedOutput;
+#[cfg(feature = "digest")]
+use generic_array::typenum::U32;
+
 use serde::ser::Serialize;
 use serde::de::DeserializeOwned;
 
@@ -20,6 +25,10 @@ pub trait GroupElement
     + Mul<Fr, Output = Self> {
     fn zero() -> Self;
     fn one() -> Self;
+    #[cfg(feature = "digest")]
+    fn hash_to_group<T>(digest: T) -> Self
+    where
+        T: FixedOutput<OutputSize = U32>;
     fn random<R: Rng>(rng: &mut R) -> Self;
     fn is_zero(&self) -> bool;
     fn double(&self) -> Self;
@@ -220,6 +229,14 @@ impl<P: GroupParams> GroupElement for G<P> {
 
     fn one() -> Self {
         P::one()
+    }
+
+    #[cfg(feature = "digest")]
+    fn hash_to_group<T>(digest: T) -> Self
+    where
+        T: FixedOutput<OutputSize = U32>,
+    {
+        Self::one()
     }
 
     fn random<R: Rng>(rng: &mut R) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ extern crate serde;
 extern crate rand;
 extern crate byteorder;
 extern crate core;
+#[cfg(feature = "digest")]
+extern crate digest;
+#[cfg(feature = "digest")]
+extern crate generic_array;
 
 mod arith;
 mod fields;
@@ -13,6 +17,11 @@ use fields::FieldElement;
 use groups::GroupElement;
 use std::ops::{Add, Sub, Mul, Neg};
 use rand::{Rng, distributions::{Distribution, Standard}, thread_rng};
+
+#[cfg(feature = "digest")]
+use digest::FixedOutput;
+#[cfg(feature = "digest")]
+use generic_array::typenum::U32;
 
 use serde::ser::Serialize;
 use serde::de::DeserializeOwned;
@@ -110,6 +119,9 @@ pub trait Group
     + Mul<Fr, Output = Self> {
     fn zero() -> Self;
     fn one() -> Self;
+    #[cfg(feature = "digest")]
+    fn hash_to_group<T>(digest: T) -> Self
+        where T: FixedOutput::<OutputSize = U32>;
     fn random<R: Rng>(rng: &mut R) -> Self;
     fn is_zero(&self) -> bool;
     fn normalize(&mut self);
@@ -125,6 +137,12 @@ impl Group for G1 {
     }
     fn one() -> Self {
         G1(groups::G1::one())
+    }
+    #[cfg(feature = "digest")]
+    fn hash_to_group<T>(digest: T) -> Self
+        where T: FixedOutput::<OutputSize = U32>,
+    {
+        G1(groups::G1::hash_to_group(digest))
     }
     fn random<R: Rng>(rng: &mut R) -> Self {
         G1(groups::G1::random(rng))
@@ -190,6 +208,12 @@ impl Group for G2 {
     }
     fn one() -> Self {
         G2(groups::G2::one())
+    }
+    #[cfg(feature = "digest")]
+    fn hash_to_group<T>(digest: T) -> Self
+        where T: FixedOutput::<OutputSize = U32>,
+    {
+        G2(groups::G2::hash_to_group(digest))
     }
     fn random<R: Rng>(rng: &mut R) -> Self {
         G2(groups::G2::random(rng))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,20 @@ pub trait Group
 #[repr(C)]
 pub struct G1(groups::G1);
 
+impl G1 {
+    /// Encodes x and y coordinates as 64 bytes Vec.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0.to_affine().unwrap().into_bytes()
+    }
+
+    /// Decodes x and y coordinates if the point is on the curve.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        Some(G1(
+            groups::AffineG::<groups::G1Params>::from_bytes(bytes)?.to_jacobian()
+        ))
+    }
+}
+
 impl Group for G1 {
     fn zero() -> Self {
         G1(groups::G1::zero())
@@ -228,6 +242,20 @@ impl Group for G2 {
         };
 
         self.0 = new.to_jacobian();
+    }
+}
+
+impl G2 {
+    /// Encodes x and y coordinates as 64 bytes Vec.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0.to_affine().unwrap().into_bytes()
+    }
+
+    /// Decodes x and y coordinates.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        Some(G2(
+            groups::AffineG::<groups::G2Params>::from_bytes(bytes)?.to_jacobian()
+        ))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,13 @@ impl Gt {
     pub fn inverse(&self) -> Self {
         Gt(self.0.inverse().unwrap())
     }
+    /// Serializes the element as 384 bytes
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0.into_bytes()
+    }
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        Some(Gt(fields::Fq12::from_bytes(bytes)?))
+    }
 }
 
 pub trait SerializableGt


### PR DESCRIPTION
WIP hash-to-group

Currently, this is stubbed to return `G::one()` because I'm short on time for a PoC, but the intent is to get this compatible with whatever [`AMCL` is doing here](https://github.com/miracl/amcl/blob/master/version3/c/ecp2.c#L625)!