### PR TITLE
Fixed Stack Overflow in Display Trait implementations

### DIFF
--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -26,7 +26,7 @@ pub trait GroupElement
 }
 
 pub trait GroupParams: Sized {
-    type Base: FieldElement + Serialize + DeserializeOwned;
+    type Base: FieldElement + Serialize + DeserializeOwned + fmt::Display;
 
     fn name() -> &'static str;
     fn one() -> G<Self>;
@@ -249,6 +249,12 @@ impl<P: GroupParams> GroupElement for G<P> {
             y: e * (d - x3) - eight_c,
             z: y1z1 + y1z1,
         }
+    }
+}
+
+impl<P: GroupParams> fmt::Display for G<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {}", self.x, self.y, self.z)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ impl Distribution<Fr> for Standard {
 
 impl fmt::Display for Fr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{}", self.0)
     }
 }
 
@@ -200,7 +200,7 @@ impl Distribution<G1> for Standard {
 
 impl fmt::Display for G1 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
There was a possible Stack Overflow in the Display trait implementations for both `rabe_bn::Fr` and `rabe_bn::G1` that has been adressed in this PR.